### PR TITLE
Adiciona configuração do GitHub Actions para testes Cypress

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -1,0 +1,54 @@
+name: Cypress Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v5
+        with:
+          browser: chrome
+          headless: true
+          record: true
+          ci-build-id: ${{ github.run_id }}
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          retention-days: 7
+
+      - name: Upload Mochawesome report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mochawesome-report
+          path: cypress/reports/mochawesome
+          retention-days: 7
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_COLOR: danger
+          SLACK_TITLE: "Cypress Tests Failed"
+          SLACK_MESSAGE: "One or more Cypress tests failed in the ${{ github.workflow }} workflow."

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+  projectId: "2ysxm5",
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here


### PR DESCRIPTION
Este PR adiciona um workflow de CI/CD usando GitHub Actions para executar testes automatizados com Cypress. O workflow é acionado em cada push ou pull request para a branch main e inclui:

- Execução dos testes no navegador Chrome em um ambiente Ubuntu.
- Geração de relatórios de testes usando Mochawesome.
- Upload de screenshots e relatórios como artefatos.
- Notificação no Slack em caso de falha (opcional).

